### PR TITLE
Support TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ We announce changes on our Twitter account [@redsmin](https://twitter.com/redsmi
 
 - `CONFIG_FILE`: configuration file to read (if any), default: `/path/to/redsmin-proxy/etc/redsmin.json`
 - `REDIS_URI`: Redis URI or socket path, default `redis://127.0.0.1:6379`
-- `REDIS_AUTH`: Redis authenticat password, default `null`
+- `REDIS_AUTH`: Redis authentication password, default `null`
 - `REDSMIN_KEY`: your Redsmin server connection key, default `''`
 
 Advanced configuration:
@@ -60,6 +60,7 @@ Advanced configuration:
 - `REDSMIN_PORT`: where redsmin proxy should connect, default: `993`
 - `REDSMIN_HOSTNAME`: where redsmin proxy should connect, default `ssl.redsmin.com`
 - `DEBUG`: debug mode, default `false`
+- Prefix `REDIS_URI` with `rediss://` to connect to Redis using TLS encryption
 
 --------------------------------------------------------------------------------------------------
 

--- a/app.js
+++ b/app.js
@@ -21,7 +21,7 @@ var jsonPackage = JSON.parse(fs.readFileSync(path.resolve(__dirname, './package.
 
 var Endpoint = require('./lib/Endpoint')(log, jsonPackage, tls, process);
 
-var RedisClient = require('./lib/RedisClient')(log, net);
+var RedisClient = require('./lib/RedisClient')(log, net, tls);
 
 var RedsminProxy = require('./lib/Proxy')(config, RedisClient, Endpoint);
 

--- a/lib/RedisClient.js
+++ b/lib/RedisClient.js
@@ -6,7 +6,7 @@ var backoff = require('backoff');
 var EventEmitter = require('events').EventEmitter;
 var assert = require('assert');
 
-module.exports = function (log, net) {
+module.exports = function (log, net, tls) {
   assert(_.isObject(log));
   assert(_.isObject(net));
 
@@ -46,11 +46,12 @@ module.exports = function (log, net) {
 
   _.extend(RedisClient.prototype, require('events').EventEmitter.prototype, {
     PREFIX: 'redis://',
+    TLS_PREFIX: 'rediss://',
 
     updatePortAndHostname: function (uri) {
       uri = uri || this.PREFIX + '127.0.0.1:6379';
 
-      if (uri[0] !== '/' && uri.indexOf(this.PREFIX) !== 0) { // add "redis://" if it was not specified
+      if (uri[0] !== '/' && uri.indexOf(this.PREFIX) !== 0 && uri.indexOf(this.TLS_PREFIX) !== 0) { // add "redis://" if it was not specified
         uri = this.PREFIX + uri;
       }
 
@@ -59,12 +60,13 @@ module.exports = function (log, net) {
         this.uri = uri;
         this.port = parsedUri.port ||  6379;
         this.hostname = parsedUri.hostname || '127.0.0.1';
+        this.tls = (parsedUri.protocol + '//' === this.TLS_PREFIX);
       } else {
         this.uri = uri; // a socket path
         this.port = null;
         this.hostname = null;
+        this.tls = false;
       }
-
     },
 
     connect: function (uri) {
@@ -80,7 +82,11 @@ module.exports = function (log, net) {
 
       if (this.port && this.hostname) {
         // port
-        this.socket = net.createConnection(this.port, this.hostname, this.onConnected);
+        if (this.tls) {
+          this.socket = tls.connect(this.port, this.hostname, this.onConnected);
+        } else {
+          this.socket = net.createConnection(this.port, this.hostname, this.onConnected);
+        }
       } else {
         // socket
         this.socket = net.createConnection({

--- a/lib/RedisClient.test.js
+++ b/lib/RedisClient.test.js
@@ -7,7 +7,7 @@ var t = require('chai').assert;
 
 
 describe('RedisClient', function () {
-  var RedisClient, R, endpoint, log, net;
+  var RedisClient, R, endpoint, log, net, tls;
   var HOST = '127.0.1.1';
   var PORT = 6378;
 
@@ -16,7 +16,10 @@ describe('RedisClient', function () {
     net = {
       createConnection: _.noop
     };
-    RedisClient = RedisClientFactory(log, net);
+    tls = {
+      connect: _.noop
+    };
+    RedisClient = RedisClientFactory(log, net, tls);
     endpoint = stubRedsminEndpoint();
     R = new RedisClient(endpoint);
   });

--- a/lib/RedisClient.test.js
+++ b/lib/RedisClient.test.js
@@ -50,6 +50,20 @@ describe('RedisClient', function () {
     R.connect('redis://' + HOST + ':' + PORT);
   });
 
+  it('should connect with TLS', function (done) {
+    tls.connect = tcreateConnection(t, PORT, HOST);
+
+
+    R.on('connect', function () {
+      t.ok(true, 'connected');
+      t.equal(R.connected, true);
+      done();
+    });
+
+    t.equal(R.connected, false);
+    R.connect('rediss://' + HOST + ':' + PORT);
+  });
+
   it('should updatePortAndHostname', function () {
     R.updatePortAndHostname(HOST + ':' + PORT);
     t.equal(R.uri, 'redis://' + HOST + ':' + PORT);


### PR DESCRIPTION
AWS ElastiCache supports [TLS for in-transit encryption to Redis](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/in-transit-encryption.html).

This PR adds support to Redsmin proxy for TLS encryption using the [`rediss://` URL scheme](https://www.iana.org/assignments/uri-schemes/prov/rediss).

Particle is currently using the forked version of Redsmin proxy for our production ElastiCache Redis instances with TLS and it works great!